### PR TITLE
feat: hide Gemini model when API key is not set

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,0 +1,7 @@
+import { getAvailableModels } from "@/lib/ai/models"
+
+export async function GET() {
+  return Response.json(getAvailableModels(), {
+    headers: { "Cache-Control": "no-store" },
+  })
+}

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { startTransition, useMemo, useOptimistic, useState } from 'react';
+import useSWR from 'swr';
 
 import { saveChatModelAsCookie } from '@/app/(chat)/actions';
 import { Button } from '@/components/ui/button';
@@ -25,9 +26,16 @@ export function ModelSelector({
   const [optimisticModelId, setOptimisticModelId] =
     useOptimistic(selectedModelId);
 
+  const { data: availableModels } = useSWR('/api/models', (url: string) =>
+    fetch(url).then((r) => r.json()),
+    { dedupingInterval: 3_600_000 }
+  );
+
+  const models = availableModels ?? chatModels;
+
   const selectedChatModel = useMemo(
-    () => chatModels.find((chatModel) => chatModel.id === optimisticModelId),
-    [optimisticModelId],
+    () => models.find((m: { id: string }) => m.id === optimisticModelId),
+    [optimisticModelId, models],
   );
 
   return (
@@ -49,7 +57,7 @@ export function ModelSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[300px]">
-        {chatModels.map((chatModel) => {
+        {models.map((chatModel: { id: string; name: string; description: string }) => {
           const { id } = chatModel;
 
           return (

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -4,6 +4,7 @@ interface ChatModel {
   id: string
   name: string
   description: string
+  provider: string
 }
 
 export const chatModels: Array<ChatModel> = [
@@ -11,30 +12,43 @@ export const chatModels: Array<ChatModel> = [
     id: "gemini-2.5-flash",
     name: "Gemini 2.5 Flash",
     description: "High performance, low cost model",
+    provider: "google",
   },
   {
     id: "gpt-4o-mini",
     name: "GPT-4o Mini",
     description: "Small model for fast, lightweight tasks",
+    provider: "openai",
   },
   {
     id: "gpt-4.1",
     name: "GPT-4.1",
     description: "Flagship model for complex tasks",
+    provider: "openai",
   },
   {
     id: "claude-haiku-4-5",
     name: "Claude Haiku 4.5",
     description: "Fastest model with near-frontier intelligence",
+    provider: "anthropic",
   },
   {
     id: "claude-sonnet-4-5",
     name: "Claude Sonnet 4.5",
     description: "Smartest model for complex agents and coding",
+    provider: "anthropic",
   },
-  // {
-  //   id: 'chat-model-reasoning',
-  //   name: 'Reasoning model',
-  //   description: 'Uses advanced reasoning',
-  // },
 ]
+
+export function getAvailableModels(): Array<ChatModel> {
+  const hasGoogle = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY?.trim()
+  const hasOpenAI = !!process.env.OPENAI_API_KEY?.trim()
+  const hasAnthropic = !!process.env.ANTHROPIC_API_KEY?.trim()
+
+  return chatModels.filter((m) => {
+    if (m.provider === "google") return hasGoogle
+    if (m.provider === "openai") return hasOpenAI
+    if (m.provider === "anthropic") return hasAnthropic
+    return true
+  })
+}


### PR DESCRIPTION
## Summary

- Adds `getAvailableModels()` to `lib/ai/models.ts` that filters models server-side based on which provider API keys (`GOOGLE_GENERATIVE_AI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) are present
- New `app/api/models/route.ts` exposes the filtered list (no-cache since it's env-dependent)
- `ModelSelector` now fetches from `/api/models` via SWR and renders only available models, falling back to the full static list while loading

## Test plan

- [ ] With `GOOGLE_GENERATIVE_AI_API_KEY` set: Gemini 2.5 Flash appears in the model selector
- [ ] With `GOOGLE_GENERATIVE_AI_API_KEY` unset/empty: Gemini 2.5 Flash is hidden
- [ ] Other models (OpenAI, Anthropic) unaffected when their keys are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)